### PR TITLE
core 3.0 test run successful

### DIFF
--- a/src/AuthWebApp/AuthWebApp.csproj
+++ b/src/AuthWebApp/AuthWebApp.csproj
@@ -1,14 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
-
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-  </ItemGroup>
 
 </Project>

--- a/src/AuthWebApp/Program.cs
+++ b/src/AuthWebApp/Program.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace AuthWebApp
@@ -14,11 +15,14 @@ namespace AuthWebApp
     {
         public static void Main(string[] args)
         {
-            CreateWebHostBuilder(args).Build().Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
     }
 }

--- a/src/AuthWebApp/Startup.cs
+++ b/src/AuthWebApp/Startup.cs
@@ -1,15 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.HttpsPolicy;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace AuthWebApp
 {
@@ -25,13 +20,6 @@ namespace AuthWebApp
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
-
             services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
            .AddCookie(options =>
            {
@@ -40,12 +28,13 @@ namespace AuthWebApp
                options.ExpireTimeSpan = TimeSpan.FromDays(1);
            }
            );
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+            services.AddControllersWithViews();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            ConfigureAdditionalMiddleware(app);
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
@@ -58,17 +47,15 @@ namespace AuthWebApp
                 // app.UseHsts();
                 ConfigureHttps(app);
             }
-
             app.UseStaticFiles();
-            app.UseCookiePolicy();
+            app.UseRouting();
             app.UseAuthentication();
-
-            ConfigureAdditionalMiddleware(app);
-            app.UseMvc(routes =>
+            app.UseAuthorization();
+            app.UseEndpoints(endpoints =>
             {
-                routes.MapRoute(
+                endpoints.MapControllerRoute(
                     name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
+                    pattern: "{controller=Home}/{action=Index}/{id?}");
             });
         }
 

--- a/tests/AuthWebAppIntegrationTest/AuthWebAppiIntegrationTest.csproj
+++ b/tests/AuthWebAppIntegrationTest/AuthWebAppiIntegrationTest.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/tests/AuthWebAppIntegrationTest/AuthenticatedTestRequestMiddleware.cs
+++ b/tests/AuthWebAppIntegrationTest/AuthenticatedTestRequestMiddleware.cs
@@ -1,4 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
+using System;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;

--- a/tests/AuthWebAppIntegrationTest/TestWebApplicationFactory.cs
+++ b/tests/AuthWebAppIntegrationTest/TestWebApplicationFactory.cs
@@ -1,15 +1,18 @@
 ﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Hosting;
 
 namespace AuthWebAppIntegrationTest
 {
     public class TestWebApplicationFactory<TEntryPoint> : WebApplicationFactory<TEntryPoint> where TEntryPoint : class
     {
-        protected override IWebHostBuilder CreateWebHostBuilder()
+        protected override IHostBuilder CreateHostBuilder()
         {
-            return WebHost.CreateDefaultBuilder(null)
-                       .UseStartup<TestServerStartup>(); //UseStartup have no relations with type parameter TEntryPoint, use our all new TestServerStartup here.
+            return base.CreateHostBuilder().ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseStartup<TestServerStartup>();
+            });
         }
     }
 }

--- a/tests/AuthWebAppIntegrationTest/UnitTest1.cs
+++ b/tests/AuthWebAppIntegrationTest/UnitTest1.cs
@@ -45,7 +45,7 @@ namespace AuthWebAppIntegrationTest
 
             // Act
             var response = await client.GetAsync("/Home/Privacy");
-
+            
             // Assert
             response.EnsureSuccessStatusCode(); // Status Code 200-299
             Assert.Equal("text/html; charset=utf-8",


### PR DESCRIPTION
3.0 的 自定义 startup 的机制跟 2.2 有点不同。

除了常规的 2.2 迁移到 3.0，更新引用之外，关键在于 `TestWebApplicationFactory<TEntryPoint>` 里面从 `override CreateWebHostBuilder()` 改为 `override CreateHostBuilder()`，并且里面的构建的内容要与新版本的 `program` 里的典型构建一致。